### PR TITLE
feat: allow state lookup by full name in /saw command

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -32,6 +32,9 @@ public class BotCommandHandler
         {"VA","Virginia"},{"WA","Washington"},{"WV","West Virginia"},{"WI","Wisconsin"},{"WY","Wyoming"}
     };
 
+    private static readonly Dictionary<string, string> StateNameToAbbr =
+        StateNames.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.OrdinalIgnoreCase);
+
     public BotCommandHandler(ITelegramBotClient bot, TripStateService stateService)
     {
         _bot = bot;
@@ -110,14 +113,19 @@ public class BotCommandHandler
             pending.PendingCommand = "saw";
             await _stateService.SaveAsync(pending);
             await _bot.SendMessage(chatId,
-                "Which state did you spot? Reply with the 2-letter abbreviation (e.g. CA, TX, NY).",
+                "Which state did you spot? Reply with the 2-letter abbreviation or full name (e.g. CA, TX, California).",
                 replyMarkup: new ForceReplyMarkup());
             return null;
         }
 
-        var abbr = args[0].ToUpper();
-        if (!AllStates.Contains(abbr))
-            return $"❓ <b>{abbr}</b> isn't a recognized US state. Use a 2-letter abbreviation like CA, TX, NY.";
+        var input = string.Join(" ", args);
+        string abbr;
+        if (AllStates.Contains(input))
+            abbr = input.ToUpper();
+        else if (StateNameToAbbr.TryGetValue(input, out var matched))
+            abbr = matched;
+        else
+            return $"❓ <b>{input}</b> isn't a recognized US state. Use a 2-letter abbreviation (CA) or full name (California).";
 
         var state = await _stateService.GetOrCreateAsync(chatId);
         state.PendingCommand = null;
@@ -188,7 +196,7 @@ public class BotCommandHandler
     private static string GetHelp() =>
         "<b>License Plate Game 🚗</b>\n\n" +
         "/newtrip [name] — start a fresh trip\n" +
-        "/saw CA — log a state you spotted\n" +
+        "/saw CA — log a state you spotted (abbreviation or full name)\n" +
         "/status — see your progress\n" +
         "/missing — see what's left\n" +
         "/undo — remove the last logged state\n" +

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Telegram bot for playing the license plate game on road trips. Track which US 
 
 ## Features
 
-- `/saw CA` — log a state you spotted (tap `/saw` with no argument and the bot will prompt you)
+- `/saw CA` or `/saw California` — log a state you spotted by abbreviation or full name (tap `/saw` with no argument and the bot will prompt you)
 - `/status` — see your progress with a visual progress bar
 - `/missing` — see which states you still need
 - `/undo` — remove the last logged state
@@ -195,7 +195,7 @@ Paste:
 
 ```
 newtrip - Start a new trip (clears previous state)
-saw - Log a state plate you spotted e.g. /saw CA
+saw - Log a state plate you spotted e.g. /saw CA or /saw California
 status - See your current progress
 missing - See which states you still need
 undo - Remove the last logged state
@@ -220,7 +220,7 @@ Both you and your chat partner can now send commands and see each other's update
 | Command | Description | Example |
 |---|---|---|
 | `/newtrip [name]` | Start a fresh trip, clears all state | `/newtrip Colorado 2026` |
-| `/saw [state]` | Log a state you spotted; omit the abbreviation and the bot will prompt you | `/saw CA` |
+| `/saw [state]` | Log a state you spotted by abbreviation or full name; omit the state and the bot will prompt you | `/saw CA` or `/saw California` |
 | `/status` | Show progress and states found so far | `/status` |
 | `/missing` | List states not yet found | `/missing` |
 | `/undo` | Remove the last logged state | `/undo` |

--- a/agents.md
+++ b/agents.md
@@ -77,6 +77,8 @@ Local values live in `local.settings.json` (gitignored). Production values are s
 
 Always run `dotnet build` and confirm it succeeds (0 errors) before declaring a code change complete.
 
+Always update `README.md` if the change affects user-facing behavior, commands, or examples.
+
 ## Testing
 
 No automated tests currently. Test manually via Telegram with ngrok running locally. Key scenarios to verify after any change:


### PR DESCRIPTION
Users can now log a state using its full name (e.g. /saw California,
/saw New York) in addition to the 2-letter abbreviation. Input is
joined to support multi-word state names before matching.

https://claude.ai/code/session_01Njoa32fF2cipF56aazikCS