### PR TITLE
ci: add GitHub Actions workflow for CI/CD

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ on:
 env:
   DOTNET_VERSION: '8.0.x'
   AZURE_FUNCTIONAPP_NAME: 'func-licenseplate-bot'
-  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: './publish'
 
 jobs:
   build:
@@ -34,31 +34,34 @@ jobs:
 
       - name: Publish
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: dotnet publish --no-build --configuration Release --output ./publish
+        run: dotnet publish --no-build --configuration Release --output ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
 
       - name: Upload artifact
         if: github.ref == 'refs/heads/main' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: function-app
-          path: ./publish
+          path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
 
   deploy:
     name: Deploy
     runs-on: ubuntu-latest
     needs: build
     if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+    concurrency:
+      group: deploy-main
+      cancel-in-progress: false
 
     steps:
       - name: Download artifact
         uses: actions/download-artifact@v4
         with:
           name: function-app
-          path: ./publish
+          path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
 
       - name: Deploy to Azure Functions
         uses: Azure/functions-action@v1
         with:
           app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
-          package: ./publish
+          package: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
           publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,0 +1,64 @@
+name: CI/CD
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+env:
+  DOTNET_VERSION: '8.0.x'
+  AZURE_FUNCTIONAPP_NAME: 'func-licenseplate-bot'
+  AZURE_FUNCTIONAPP_PACKAGE_PATH: '.'
+
+jobs:
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore dependencies
+        run: dotnet restore
+
+      - name: Build
+        run: dotnet build --no-restore --configuration Release
+
+      - name: Publish
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: dotnet publish --no-build --configuration Release --output ./publish
+
+      - name: Upload artifact
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        uses: actions/upload-artifact@v4
+        with:
+          name: function-app
+          path: ./publish
+
+  deploy:
+    name: Deploy
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Download artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: function-app
+          path: ./publish
+
+      - name: Deploy to Azure Functions
+        uses: Azure/functions-action@v1
+        with:
+          app-name: ${{ env.AZURE_FUNCTIONAPP_NAME }}
+          package: ./publish
+          publish-profile: ${{ secrets.AZURE_FUNCTIONAPP_PUBLISH_PROFILE }}

--- a/LicensePlateBot.csproj
+++ b/LicensePlateBot.csproj
@@ -7,6 +7,12 @@
     <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
   <ItemGroup>
+    <None Update="host.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <CopyToPublishDirectory>PreserveNewest</CopyToPublishDirectory>
+    </None>
+  </ItemGroup>
+  <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Functions.Worker" Version="1.23.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ az functionapp config appsettings set \
 
 ### 4. Deploy
 
+Deployment happens automatically via GitHub Actions when you push to `main` (see [CI/CD](#cicd) below). To deploy manually:
+
 ```bash
 func azure functionapp publish func-licenseplate-bot
 ```
@@ -180,6 +182,25 @@ Copy the `default` key value.
 curl -X POST "https://api.telegram.org/bot<YOUR_TOKEN>/setWebhook" \
   -d "url=https://func-licenseplate-bot.azurewebsites.net/api/telegram?code=<FUNCTION_KEY>"
 ```
+
+---
+
+## CI/CD
+
+A GitHub Actions workflow (`.github/workflows/ci-cd.yml`) runs on every pull request to `main` and every push to `main`.
+
+| Event | Jobs run |
+|---|---|
+| Pull request to `main` | Build only |
+| Push to `main` | Build + deploy to Azure Functions |
+
+### Required secret
+
+Add the Azure Function publish profile as a repository secret named `AZURE_FUNCTIONAPP_PUBLISH_PROFILE`:
+
+1. Azure Portal → Function App `func-licenseplate-bot` → **Overview** → **Get publish profile** — download the file
+2. GitHub repo → **Settings** → **Secrets and variables** → **Actions** → **New repository secret**
+3. Name: `AZURE_FUNCTIONAPP_PUBLISH_PROFILE`, value: paste the contents of the downloaded file
 
 ---
 
@@ -232,6 +253,9 @@ Both you and your chat partner can now send commands and see each other's update
 
 ```
 LicensePlateBot/
+├── .github/
+│   └── workflows/
+│       └── ci-cd.yml        # GitHub Actions CI/CD pipeline
 ├── LicensePlateBot.csproj   # Project file and NuGet dependencies
 ├── host.json                # Azure Functions host configuration
 ├── local.settings.json      # Local dev secrets (gitignored)


### PR DESCRIPTION
Builds on all PRs targeting main and on pushes to main.
Deploys to Azure Functions (func-licenseplate-bot) on push to main
using the AZURE_FUNCTIONAPP_PUBLISH_PROFILE secret.

https://claude.ai/code/session_01RDK2gaQGh5KwQz2U4M2aV1