### PR TITLE
Preserve game history across trips with /history command

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -74,6 +74,7 @@ public class BotCommandHandler
                 "/status"              => await HandleStatus(chatId),
                 "/missing"             => await HandleMissing(chatId),
                 "/undo"                => await HandleUndo(chatId),
+                "/history"             => await HandleHistory(chatId),
                 "/help"                => GetHelp(),
                 _                      => null
             };
@@ -193,6 +194,22 @@ public class BotCommandHandler
         return $"↩️ Removed <b>{StateNames[removed]}</b> ({removed}). Back to {seen.Count}/50.";
     }
 
+    private async Task<string> HandleHistory(long chatId)
+    {
+        var history = await _stateService.GetHistoryAsync(chatId);
+        if (history.Count == 0)
+            return "No previous trips yet. Start a new trip with /newtrip!";
+
+        var lines = history.Select((t, i) =>
+        {
+            var seen = _stateService.DeserializeStates(t.SeenStatesJson);
+            var date = t.StartedAt.ToString("MMM d, yyyy");
+            return $"{i + 1}. <b>{t.TripName}</b> ({date}) — {seen.Count}/50 states";
+        });
+
+        return "📋 <b>Trip History</b>\n\n" + string.Join("\n", lines);
+    }
+
     private static string GetHelp() =>
         "<b>License Plate Game 🚗</b>\n\n" +
         "/newtrip [name] — start a fresh trip\n" +
@@ -200,6 +217,7 @@ public class BotCommandHandler
         "/status — see your progress\n" +
         "/missing — see what's left\n" +
         "/undo — remove the last logged state\n" +
+        "/history — view results from previous trips\n" +
         "/help — show this message";
 
     private static string BuildProgressBar(int current, int total)

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -200,11 +200,12 @@ public class BotCommandHandler
         if (history.Count == 0)
             return "No previous trips yet. Start a new trip with /newtrip!";
 
-        var lines = history.Select((t, i) =>
+        var lines = history.Take(25).Select((t, i) =>
         {
             var seen = _stateService.DeserializeStates(t.SeenStatesJson);
             var date = t.StartedAt.ToString("MMM d, yyyy");
-            return $"{i + 1}. <b>{t.TripName}</b> ({date}) — {seen.Count}/50 states";
+            var name = System.Net.WebUtility.HtmlEncode(t.TripName);
+            return $"{i + 1}. <b>{name}</b> ({date}) — {seen.Count}/50 states";
         });
 
         return "📋 <b>Trip History</b>\n\n" + string.Join("\n", lines);

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ A Telegram bot for playing the license plate game on road trips. Track which US 
 - `/status` — see your progress with a visual progress bar
 - `/missing` — see which states you still need
 - `/undo` — remove the last logged state
-- `/newtrip` — start fresh for a new trip
+- `/newtrip` — start fresh for a new trip (previous trip is saved automatically)
+- `/history` — view results from all previous trips in this chat
 
 State is stored per Telegram chat, so any member of a group chat can log plates and everyone sees the updates in real time.
 
@@ -215,11 +216,12 @@ This enables the `/` command popup in Telegram so you can tap commands instead o
 Paste:
 
 ```
-newtrip - Start a new trip (clears previous state)
+newtrip - Start a new trip (previous trip is saved to history)
 saw - Log a state plate you spotted e.g. /saw CA or /saw California
 status - See your current progress
 missing - See which states you still need
 undo - Remove the last logged state
+history - View results from previous trips
 help - Show all commands
 ```
 
@@ -240,11 +242,12 @@ Both you and your chat partner can now send commands and see each other's update
 
 | Command | Description | Example |
 |---|---|---|
-| `/newtrip [name]` | Start a fresh trip, clears all state | `/newtrip Colorado 2026` |
+| `/newtrip [name]` | Start a fresh trip; current trip is saved to history if any states were logged | `/newtrip Colorado 2026` |
 | `/saw [state]` | Log a state you spotted by abbreviation or full name; omit the state and the bot will prompt you | `/saw CA` or `/saw California` |
 | `/status` | Show progress and states found so far | `/status` |
 | `/missing` | List states not yet found | `/missing` |
 | `/undo` | Remove the last logged state | `/undo` |
+| `/history` | Show results from all previous trips in this chat | `/history` |
 | `/help` | Show command reference | `/help` |
 
 ---

--- a/TripState.cs
+++ b/TripState.cs
@@ -5,7 +5,7 @@ namespace LicensePlateBot.Models;
 
 public class TripState : ITableEntity
 {
-    // PartitionKey = chat ID, RowKey = "currentTrip"
+    // PartitionKey = chat ID, RowKey = "currentTrip" for active trip or "trip_<yyyyMMddHHmmss>" for archived trips
     public string PartitionKey { get; set; } = string.Empty;
     public string RowKey { get; set; } = "currentTrip";
     public DateTimeOffset? Timestamp { get; set; }

--- a/TripState.cs
+++ b/TripState.cs
@@ -15,4 +15,5 @@ public class TripState : ITableEntity
     public string SeenStatesJson { get; set; } = "[]";  // JSON array of state abbreviations
     public DateTimeOffset StartedAt { get; set; } = DateTimeOffset.UtcNow;
     public string? PendingCommand { get; set; }  // conversational state, e.g. "saw"
+    public DateTimeOffset? EndedAt { get; set; }  // set when trip is archived
 }

--- a/TripStateService.cs
+++ b/TripStateService.cs
@@ -40,6 +40,27 @@ public class TripStateService
 
     public async Task ResetAsync(long chatId, string tripName)
     {
+        // Archive current trip if it has any states logged
+        try
+        {
+            var response = await _tableClient.GetEntityAsync<TripState>(chatId.ToString(), "currentTrip");
+            var existing = response.Value;
+            if (existing.SeenStatesJson != "[]")
+            {
+                var archived = new TripState
+                {
+                    PartitionKey = chatId.ToString(),
+                    RowKey = $"trip_{existing.StartedAt:yyyyMMddHHmmss}",
+                    TripName = existing.TripName,
+                    SeenStatesJson = existing.SeenStatesJson,
+                    StartedAt = existing.StartedAt,
+                    EndedAt = DateTimeOffset.UtcNow
+                };
+                await _tableClient.UpsertEntityAsync(archived, TableUpdateMode.Replace);
+            }
+        }
+        catch (RequestFailedException ex) when (ex.Status == 404) { }
+
         var state = new TripState
         {
             PartitionKey = chatId.ToString(),
@@ -48,6 +69,20 @@ public class TripStateService
             StartedAt = DateTimeOffset.UtcNow
         };
         await _tableClient.UpsertEntityAsync(state, TableUpdateMode.Replace);
+    }
+
+    public async Task<List<TripState>> GetHistoryAsync(long chatId)
+    {
+        var partitionKey = chatId.ToString();
+        var history = new List<TripState>();
+
+        var query = _tableClient.QueryAsync<TripState>(
+            filter: $"PartitionKey eq '{partitionKey}' and RowKey ne 'currentTrip'");
+
+        await foreach (var entity in query)
+            history.Add(entity);
+
+        return history.OrderByDescending(t => t.StartedAt).ToList();
     }
 
     public List<string> DeserializeStates(string json) =>

--- a/TripStateService.cs
+++ b/TripStateService.cs
@@ -45,7 +45,7 @@ public class TripStateService
         {
             var response = await _tableClient.GetEntityAsync<TripState>(chatId.ToString(), "currentTrip");
             var existing = response.Value;
-            if (existing.SeenStatesJson != "[]")
+            if (DeserializeStates(existing.SeenStatesJson).Count > 0)
             {
                 var archived = new TripState
                 {


### PR DESCRIPTION
When /newtrip is called, the current trip is archived to Table Storage
(RowKey = "trip_<yyyyMMddHHmmss>") if it has any states logged.
New /history command lists all previous trips newest-first with state counts.

https://claude.ai/code/session_019LSoUCJJr2dGtqmGbdBjFV