### PR TITLE
fix: include .azurefunctions folder in CI/CD deploy package

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           name: function-app
           path: ${{ env.AZURE_FUNCTIONAPP_PACKAGE_PATH }}
+          include-hidden-files: true
 
   deploy:
     name: Deploy


### PR DESCRIPTION
## Summary

- Adds `include-hidden-files: true` to the `upload-artifact` step

## Root cause

`actions/upload-artifact@v4` excludes hidden files and folders (anything starting with `.`) by default. The `.azurefunctions` folder — which the isolated worker runtime requires to discover functions — is generated correctly by `dotnet publish` but was silently dropped during artifact upload, so the deploy job never received it.

This produced the App Insights trace: *"Could not find the .azurefunctions folder in the deployed artifacts of a .NET isolated function app."*

## Why it worked before

A recent update to `Microsoft.Azure.Functions.Worker.Sdk` (now at 1.17.4) started generating and requiring the `.azurefunctions` folder where previously function discovery worked without it. Once the SDK started producing that folder, the upload-artifact exclusion of hidden files became a breaking problem.

https://claude.ai/code/session_019LSoUCJJr2dGtqmGbdBjFV