### PR TITLE
Auto-register BotFather command list on startup

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -35,6 +35,9 @@ public class BotCommandHandler
     private static readonly Dictionary<string, string> StateNameToAbbr =
         StateNames.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.OrdinalIgnoreCase);
 
+    // Canonical command list registered with BotFather on startup.
+    // /start is intentionally omitted — it is an internal alias for /newtrip
+    // required by Telegram for new users, not a user-facing command.
     public static readonly Telegram.Bot.Types.BotCommand[] Commands =
     [
         new() { Command = "saw",      Description = "Log a state you spotted (e.g. /saw CA)" },

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -35,6 +35,17 @@ public class BotCommandHandler
     private static readonly Dictionary<string, string> StateNameToAbbr =
         StateNames.ToDictionary(kv => kv.Value, kv => kv.Key, StringComparer.OrdinalIgnoreCase);
 
+    public static readonly Telegram.Bot.Types.BotCommand[] Commands =
+    [
+        new() { Command = "saw",      Description = "Log a state you spotted (e.g. /saw CA)" },
+        new() { Command = "status",   Description = "See your current progress" },
+        new() { Command = "missing",  Description = "See which states are still needed" },
+        new() { Command = "undo",     Description = "Remove the last logged state" },
+        new() { Command = "newtrip",  Description = "Start a fresh trip" },
+        new() { Command = "history",  Description = "View results from previous trips" },
+        new() { Command = "help",     Description = "Show available commands" },
+    ];
+
     public BotCommandHandler(ITelegramBotClient bot, TripStateService stateService)
     {
         _bot = bot;
@@ -213,11 +224,11 @@ public class BotCommandHandler
 
     private static string GetHelp() =>
         "<b>License Plate Game 🚗</b>\n\n" +
-        "/newtrip [name] — start a fresh trip\n" +
         "/saw CA — log a state you spotted (abbreviation or full name)\n" +
         "/status — see your progress\n" +
         "/missing — see what's left\n" +
         "/undo — remove the last logged state\n" +
+        "/newtrip [name] — start a fresh trip\n" +
         "/history — view results from previous trips\n" +
         "/help — show this message";
 

--- a/Program.cs
+++ b/Program.cs
@@ -1,6 +1,7 @@
 using Microsoft.Azure.Functions.Worker;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
 using Telegram.Bot;
 
 var host = new HostBuilder()
@@ -19,10 +20,21 @@ var host = new HostBuilder()
 
 host.Run();
 
-class BotCommandRegistrar(ITelegramBotClient bot) : IHostedService
+class BotCommandRegistrar(ITelegramBotClient bot, ILogger<BotCommandRegistrar> logger) : IHostedService
 {
-    public Task StartAsync(CancellationToken ct) =>
-        bot.SetMyCommands(BotCommandHandler.Commands, cancellationToken: ct);
+    public async Task StartAsync(CancellationToken ct)
+    {
+        try
+        {
+            await bot.SetMyCommands(BotCommandHandler.Commands, cancellationToken: ct);
+        }
+        catch (Exception ex)
+        {
+            // Best-effort: a Telegram outage or rate-limit should not prevent the
+            // function host from starting and serving webhook requests.
+            logger.LogWarning(ex, "Failed to register BotFather command list on startup.");
+        }
+    }
 
     public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
 }

--- a/Program.cs
+++ b/Program.cs
@@ -13,7 +13,16 @@ var host = new HostBuilder()
         services.AddSingleton<ITelegramBotClient>(_ => new TelegramBotClient(token));
         services.AddSingleton<TripStateService>();
         services.AddSingleton<BotCommandHandler>();
+        services.AddHostedService<BotCommandRegistrar>();
     })
     .Build();
 
 host.Run();
+
+class BotCommandRegistrar(ITelegramBotClient bot) : IHostedService
+{
+    public Task StartAsync(CancellationToken ct) =>
+        bot.SetMyCommands(BotCommandHandler.Commands, cancellationToken: ct);
+
+    public Task StopAsync(CancellationToken ct) => Task.CompletedTask;
+}

--- a/README.md
+++ b/README.md
@@ -205,25 +205,11 @@ Add the Azure Function publish profile as a repository secret named `AZURE_FUNCT
 
 ---
 
-## Set Up the Command Menu
+## Command Menu
 
-This enables the `/` command popup in Telegram so you can tap commands instead of typing them. Message [@BotFather](https://t.me/BotFather):
+The bot registers its command list with BotFather automatically on every startup, so the `/` command popup in Telegram stays in sync without any manual steps.
 
-```
-/mybots → select your bot → Edit Bot → Edit Commands
-```
-
-Paste:
-
-```
-newtrip - Start a new trip (previous trip is saved to history)
-saw - Log a state plate you spotted e.g. /saw CA or /saw California
-status - See your current progress
-missing - See which states you still need
-undo - Remove the last logged state
-history - View results from previous trips
-help - Show all commands
-```
+To add a new command, add an entry to the `Commands` array in `BotCommandHandler.cs` — it will be registered on the next deploy.
 
 ---
 
@@ -242,11 +228,11 @@ Both you and your chat partner can now send commands and see each other's update
 
 | Command | Description | Example |
 |---|---|---|
-| `/newtrip [name]` | Start a fresh trip; current trip is saved to history if any states were logged | `/newtrip Colorado 2026` |
 | `/saw [state]` | Log a state you spotted by abbreviation or full name; omit the state and the bot will prompt you | `/saw CA` or `/saw California` |
 | `/status` | Show progress and states found so far | `/status` |
 | `/missing` | List states not yet found | `/missing` |
 | `/undo` | Remove the last logged state | `/undo` |
+| `/newtrip [name]` | Start a fresh trip; current trip is saved to history if any states were logged | `/newtrip Colorado 2026` |
 | `/history` | Show results from all previous trips in this chat | `/history` |
 | `/help` | Show command reference | `/help` |
 


### PR DESCRIPTION
## Summary

- Adds a `Commands` static array to `BotCommandHandler` as the single source of truth for the bot's command list
- Registers a `BotCommandRegistrar` hosted service that calls `SetMyCommands` on every startup, so BotFather stays in sync automatically on each deploy — no more manual copy-paste into BotFather
- Reorders commands so `/newtrip` appears after `/undo` (less-frequent action, better UX order)
- Updates README to reflect that command registration is now automatic

## Test plan

- [x] Deploy and confirm the Telegram `/` command popup reflects the correct list without any manual BotFather steps
- [x] Verify `/help` output matches the new order
- [x] Confirm all commands still function correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)