### PR TITLE
Prompt for trip name when /newtrip has no argument

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -72,7 +72,7 @@ public class BotCommandHandler
         if (isCommand)
         {
             // Clear any pending conversational state when a new command arrives
-            if (command != "/saw")
+            if (command != "/saw" && command != "/newtrip" && command != "/start")
             {
                 var s = await _stateService.GetOrCreateAsync(chatId);
                 if (s.PendingCommand is not null)
@@ -104,6 +104,12 @@ public class BotCommandHandler
                 await _stateService.SaveAsync(state);
                 reply = await HandleSaw(chatId, parts, message.From);
             }
+            else if (state.PendingCommand == "newtrip")
+            {
+                state.PendingCommand = null;
+                await _stateService.SaveAsync(state);
+                reply = await HandleNewTrip(chatId, parts);
+            }
             else
             {
                 reply = null;
@@ -114,9 +120,24 @@ public class BotCommandHandler
             await _bot.SendMessage(chatId, reply, parseMode: ParseMode.Html);
     }
 
-    private async Task<string> HandleNewTrip(long chatId, string[] args)
+    private async Task<string?> HandleNewTrip(long chatId, string[] args)
     {
-        var tripName = args.Length > 0 ? string.Join(" ", args) : "Road Trip";
+        if (args.Length == 0)
+        {
+            var pending = await _stateService.GetOrCreateAsync(chatId);
+            pending.PendingCommand = "newtrip";
+            await _stateService.SaveAsync(pending);
+            var defaultName = $"Road Trip {DateTime.UtcNow:MM/dd/yyyy}";
+            await _bot.SendMessage(chatId,
+                $"What would you like to name this trip? Reply with a name, or send <b>skip</b> to use \"{defaultName}\".",
+                parseMode: ParseMode.Html,
+                replyMarkup: new ForceReplyMarkup());
+            return null;
+        }
+
+        var tripName = string.Join(" ", args).Equals("skip", StringComparison.OrdinalIgnoreCase)
+            ? $"Road Trip {DateTime.UtcNow:MM/dd/yyyy}"
+            : string.Join(" ", args);
         await _stateService.ResetAsync(chatId, tripName);
         return $"🚗 <b>New trip started: {tripName}</b>\n\nReady to collect all 50 states! Use /saw CA to log a plate.";
     }

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -104,11 +104,12 @@ public class BotCommandHandler
                 await _stateService.SaveAsync(state);
                 reply = await HandleSaw(chatId, parts, message.From);
             }
-            else if (state.PendingCommand == "newtrip")
+            else if (state.PendingCommand is { } pc && pc.StartsWith("newtrip:"))
             {
+                var pendingDefault = pc["newtrip:".Length..];
                 state.PendingCommand = null;
                 await _stateService.SaveAsync(state);
-                reply = await HandleNewTrip(chatId, parts);
+                reply = await HandleNewTrip(chatId, parts, pendingDefault);
             }
             else
             {
@@ -120,14 +121,14 @@ public class BotCommandHandler
             await _bot.SendMessage(chatId, reply, parseMode: ParseMode.Html);
     }
 
-    private async Task<string?> HandleNewTrip(long chatId, string[] args)
+    private async Task<string?> HandleNewTrip(long chatId, string[] args, string? pendingDefault = null)
     {
         if (args.Length == 0)
         {
-            var pending = await _stateService.GetOrCreateAsync(chatId);
-            pending.PendingCommand = "newtrip";
-            await _stateService.SaveAsync(pending);
             var defaultName = $"Road Trip {DateTime.UtcNow:MM/dd/yyyy}";
+            var pending = await _stateService.GetOrCreateAsync(chatId);
+            pending.PendingCommand = $"newtrip:{defaultName}";
+            await _stateService.SaveAsync(pending);
             await _bot.SendMessage(chatId,
                 $"What would you like to name this trip? Reply with a name, or send <b>skip</b> to use \"{defaultName}\".",
                 parseMode: ParseMode.Html,
@@ -136,10 +137,10 @@ public class BotCommandHandler
         }
 
         var tripName = string.Join(" ", args).Equals("skip", StringComparison.OrdinalIgnoreCase)
-            ? $"Road Trip {DateTime.UtcNow:MM/dd/yyyy}"
+            ? (pendingDefault ?? $"Road Trip {DateTime.UtcNow:MM/dd/yyyy}")
             : string.Join(" ", args);
         await _stateService.ResetAsync(chatId, tripName);
-        return $"🚗 <b>New trip started: {tripName}</b>\n\nReady to collect all 50 states! Use /saw CA to log a plate.";
+        return $"🚗 <b>New trip started: {System.Net.WebUtility.HtmlEncode(tripName)}</b>\n\nReady to collect all 50 states! Use /saw CA to log a plate.";
     }
 
     private async Task<string?> HandleSaw(long chatId, string[] args, Telegram.Bot.Types.User? from)

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -72,7 +72,7 @@ public class BotCommandHandler
         if (isCommand)
         {
             // Clear any pending conversational state when a new command arrives
-            if (command != "/saw" && command != "/newtrip" && command != "/start")
+            if (command != "/saw")
             {
                 var s = await _stateService.GetOrCreateAsync(chatId);
                 if (s.PendingCommand is not null)
@@ -104,7 +104,7 @@ public class BotCommandHandler
                 await _stateService.SaveAsync(state);
                 reply = await HandleSaw(chatId, parts, message.From);
             }
-            else if (state.PendingCommand is { } pc && pc.StartsWith("newtrip:"))
+            else if (state.PendingCommand is { } pc && pc.StartsWith("newtrip:", StringComparison.Ordinal))
             {
                 var pendingDefault = pc["newtrip:".Length..];
                 state.PendingCommand = null;
@@ -125,7 +125,7 @@ public class BotCommandHandler
     {
         if (args.Length == 0)
         {
-            var defaultName = $"Road Trip {DateTime.UtcNow:MM/dd/yyyy}";
+            var defaultName = $"Road Trip {DateTime.UtcNow.ToString("MM/dd/yyyy", System.Globalization.CultureInfo.InvariantCulture)}";
             var pending = await _stateService.GetOrCreateAsync(chatId);
             pending.PendingCommand = $"newtrip:{defaultName}";
             await _stateService.SaveAsync(pending);

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A Telegram bot for playing the license plate game on road trips. Track which US 
 - `/status` — see your progress with a visual progress bar and a per-player leaderboard
 - `/missing` — see which states you still need
 - `/undo` — remove the last logged state
-- `/newtrip` — start fresh for a new trip (previous trip is saved automatically)
+- `/newtrip [name]` — start fresh for a new trip; if no name is given, the bot asks for one (default: `Road Trip MM/DD/YYYY`)
 - `/history` — view results from all previous trips, including the top spotter for each
 
 State is stored per Telegram chat, so any member of a group chat can log plates and everyone sees the updates in real time.
@@ -232,7 +232,7 @@ Both you and your chat partner can now send commands and see each other's update
 | `/status` | Show progress, states found, and a per-player leaderboard | `/status` |
 | `/missing` | List states not yet found | `/missing` |
 | `/undo` | Remove the last logged state | `/undo` |
-| `/newtrip [name]` | Start a fresh trip; current trip is saved to history if any states were logged | `/newtrip Colorado 2026` |
+| `/newtrip [name]` | Start a fresh trip; if no name is given, the bot asks for one (default: `Road Trip MM/DD/YYYY`); current trip is saved to history if any states were logged | `/newtrip Colorado 2026` |
 | `/history` | Show results from all previous trips in this chat | `/history` |
 | `/help` | Show command reference | `/help` |
 

--- a/agents.md
+++ b/agents.md
@@ -73,6 +73,14 @@ Local values live in `local.settings.json` (gitignored). Production values are s
 3. Add the command to the BotFather command list (see README)
 4. If the command needs conversational input, set `PendingCommand` and handle the follow-up in the non-slash branch of `HandleUpdateAsync`
 
+## Branching
+
+Always create a feature branch before making any code changes. Never commit directly to `main`. Create the branch first, then make changes:
+
+```bash
+git checkout -b <feature-branch-name>
+```
+
 ## Commits
 
 Always attribute commits to Claude using the `--author` flag:


### PR DESCRIPTION
## Summary
- `/newtrip` with no args now asks for a trip name via ForceReply instead of silently defaulting to "Road Trip"
- Default name changed to `Road Trip MM/DD/YYYY` (shown as fallback option in the prompt)
- Sending `skip` in response uses the date-based default
- Inline usage (`/newtrip My Trip`) unchanged

Closes #12

## Test plan
- [ ] Send `/newtrip` with no args — bot should ask for a name with ForceReply
- [ ] Reply with a custom name — trip should start with that name
- [ ] Reply with `skip` — trip should start with `Road Trip MM/DD/YYYY`
- [ ] Send `/newtrip My Trip` — trip should start immediately with "My Trip"
- [ ] Send `/newtrip` then a different command before replying — pending state should be cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)