### PR TITLE
Handle missing usernames gracefully in leaderboard and history

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -215,7 +215,8 @@ public class BotCommandHandler
             .OrderByDescending(g => g.Count())
             .Select(g =>
             {
-                var spotterName = g.First().UserName is { Length: > 0 } n ? n : "Unknown";
+                var spotterName = g.Select(s => s.UserName)
+                    .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? "Unknown";
                 return $"{System.Net.WebUtility.HtmlEncode(spotterName)} — {g.Count()}";
             })
             .ToList();
@@ -276,7 +277,7 @@ public class BotCommandHandler
                 .Where(s => s.UserId != 0)
                 .GroupBy(s => s.UserId)
                 .OrderByDescending(g => g.Count())
-                .Select(g => g.First().UserName is { Length: > 0 } n ? n : "Unknown")
+                .Select(g => g.Select(s => s.UserName).FirstOrDefault(userName => !string.IsNullOrEmpty(userName)) ?? "Unknown")
                 .FirstOrDefault();
             var mvp = topSpotter is not null ? $" 🏆 {System.Net.WebUtility.HtmlEncode(topSpotter)}" : "";
             return $"{i + 1}. <b>{name}</b> ({date}) — {sightings.Count}/50 states{mvp}";

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -210,10 +210,14 @@ public class BotCommandHandler
                      $"<b>Found:</b> {stateList}";
 
         var leaderboard = sightings
-            .Where(s => s.UserId != 0 && s.UserName.Length > 0)
+            .Where(s => s.UserId != 0)
             .GroupBy(s => s.UserId)
             .OrderByDescending(g => g.Count())
-            .Select(g => $"{System.Net.WebUtility.HtmlEncode(g.First().UserName)} — {g.Count()}")
+            .Select(g =>
+            {
+                var spotterName = g.First().UserName is { Length: > 0 } n ? n : "Unknown";
+                return $"{System.Net.WebUtility.HtmlEncode(spotterName)} — {g.Count()}";
+            })
             .ToList();
 
         if (leaderboard.Count > 0)
@@ -269,10 +273,10 @@ public class BotCommandHandler
             var date = t.StartedAt.ToString("MMM d, yyyy");
             var name = System.Net.WebUtility.HtmlEncode(t.TripName);
             var topSpotter = sightings
-                .Where(s => s.UserId != 0 && s.UserName.Length > 0)
+                .Where(s => s.UserId != 0)
                 .GroupBy(s => s.UserId)
                 .OrderByDescending(g => g.Count())
-                .Select(g => g.First().UserName)
+                .Select(g => g.First().UserName is { Length: > 0 } n ? n : "Unknown")
                 .FirstOrDefault();
             var mvp = topSpotter is not null ? $" 🏆 {System.Net.WebUtility.HtmlEncode(topSpotter)}" : "";
             return $"{i + 1}. <b>{name}</b> ({date}) — {sightings.Count}/50 states{mvp}";


### PR DESCRIPTION
## Summary
Improved null/empty username handling in leaderboard and trip history displays by treating missing usernames as "Unknown" instead of filtering them out entirely.

## Key Changes
- **Leaderboard filtering**: Removed the `s.UserName.Length > 0` check from the initial `Where` clause, allowing users with empty usernames to be included in rankings
- **Username display logic**: Added pattern matching to check if username has content; displays "Unknown" for null or empty usernames instead of skipping them
- **Trip history**: Applied the same username validation pattern when selecting the top spotter for each trip

## Implementation Details
- Uses C# pattern matching (`is { Length: > 0 } n`) to safely check for non-empty usernames
- Ensures HTML encoding is applied to valid usernames before display
- Maintains the same leaderboard ranking logic while improving data completeness
- Users with missing usernames are now visible in rankings rather than silently excluded

https://claude.ai/code/session_01En7znPizKjEsbLHPtbEG9q