### PR TITLE
Fix missing player names in group chats (snake_case deserialization + leaderboard)

### DIFF
--- a/TelegramFunction.cs
+++ b/TelegramFunction.cs
@@ -28,7 +28,8 @@ public class TelegramFunction
 
             var update = JsonSerializer.Deserialize<Update>(body, new JsonSerializerOptions
             {
-                PropertyNameCaseInsensitive = true
+                PropertyNameCaseInsensitive = true,
+                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
             });
 
             if (update is not null)

--- a/TelegramFunction.cs
+++ b/TelegramFunction.cs
@@ -7,6 +7,12 @@ using Telegram.Bot.Types;
 
 public class TelegramFunction
 {
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true,
+        PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
+    };
+
     private readonly BotCommandHandler _handler;
     private readonly ILogger<TelegramFunction> _logger;
 
@@ -26,11 +32,7 @@ public class TelegramFunction
             if (string.IsNullOrWhiteSpace(body))
                 return req.CreateResponse(HttpStatusCode.BadRequest);
 
-            var update = JsonSerializer.Deserialize<Update>(body, new JsonSerializerOptions
-            {
-                PropertyNameCaseInsensitive = true,
-                PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower
-            });
+            var update = JsonSerializer.Deserialize<Update>(body, JsonOptions);
 
             if (update is not null)
                 await _handler.HandleUpdateAsync(update);


### PR DESCRIPTION
Fixes #14

## Root cause

`TelegramFunction.cs` was deserializing Telegram webhook payloads with only `PropertyNameCaseInsensitive = true`. This handles letter casing but **not underscores**, so multi-word snake_case fields from Telegram's JSON (`first_name`, `last_name`, `is_bot`, etc.) were silently dropped. Single-word fields (`id`, `username`) worked fine since the letters match case-insensitively.

The practical effect: `user.FirstName` was always null for every user. Users with a Telegram username still showed correctly (falling back to `username`), but users without one — like Susan — had no name captured at all.

## Changes

**`TelegramFunction.cs`** — the real fix:
- Add `PropertyNamingPolicy = JsonNamingPolicy.SnakeCaseLower` to the deserializer options, so `first_name` correctly maps to `FirstName` for all users going forward

**`BotCommandHandler.cs`** — display fixes for existing data:
- Leaderboard and `/history` MVP now include all users with a valid `UserId`, not just those with a stored name, with `"Unknown"` as a fallback
- When picking a display name for a user group, scan all their sightings for the first non-empty name rather than blindly using the first record (addresses a Copilot review suggestion)

## Test plan

- [ ] Susan (no Telegram username) sends `/saw XX` — bot reply should say "spotted by Susan" (or her first name)
- [ ] `/status` leaderboard shows Susan with her real name, not "Unknown"
- [ ] Craig and Dan continue to show correctly
- [ ] `/history` MVP shows the correct top spotter name