### PR TITLE
Fix /cmd@botname command parsing on desktop and iPhone

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -64,7 +64,7 @@ public class BotCommandHandler
         var chatId = message.Chat.Id;
         var parts = text.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
         var isCommand = parts[0].StartsWith('/');
-        var command = parts[0].ToLower().TrimEnd('@'); // handle /cmd@botname format
+        var command = parts[0].ToLower().Split('@')[0]; // handle /cmd@botname format
         var args = parts.Skip(1).ToArray();
 
         string? reply;

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -63,6 +63,7 @@ public class BotCommandHandler
 
         var chatId = message.Chat.Id;
         var parts = text.Trim().Split(' ', StringSplitOptions.RemoveEmptyEntries);
+        if (parts.Length == 0) return;
         var isCommand = parts[0].StartsWith('/');
         var command = parts[0].ToLower().Split('@')[0]; // handle /cmd@botname format
         var args = parts.Skip(1).ToArray();


### PR DESCRIPTION
TrimEnd('@') only removes trailing @ characters, so /saw@BotName was
left intact and matched no switch case. Split on '@' and take [0]
correctly strips the bot suffix in all clients.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>