### PR TITLE
Add elaborate all-50-states celebration message (issue #22)

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -184,8 +184,80 @@ public class BotCommandHandler
 
         var remaining = 50 - sightings.Count;
         var credit = displayName is { Length: > 0 } ? $" by {displayName}" : "";
-        var congrats = sightings.Count == 50 ? "\n\n🎉 <b>YOU GOT ALL 50!</b> 🎉" : "";
-        return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!\n{sightings.Count}/50 states found — {remaining} to go.{congrats}";
+
+        if (sightings.Count == 50)
+        {
+            await SendAllStatesFoundCelebrationAsync(chatId, state, sightings);
+            return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!\n🏁 <b>50/50 — COMPLETE!</b> 🎆";
+        }
+
+        return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!\n{sightings.Count}/50 states found — {remaining} to go.";
+    }
+
+    private async Task SendAllStatesFoundCelebrationAsync(long chatId, TripState state, List<SightingRecord> sightings)
+    {
+        var duration = DateTimeOffset.UtcNow - state.StartedAt;
+        string durationText;
+        if (duration.TotalDays >= 1)
+        {
+            var days = (int)duration.TotalDays;
+            var hours = duration.Hours;
+            durationText = hours > 0 ? $"{days} day{(days == 1 ? "" : "s")} and {hours} hour{(hours == 1 ? "" : "s")}" : $"{days} day{(days == 1 ? "" : "s")}";
+        }
+        else if (duration.TotalHours >= 1)
+        {
+            var hrs = (int)duration.TotalHours;
+            durationText = $"{hrs} hour{(hrs == 1 ? "" : "s")}";
+        }
+        else
+        {
+            var mins = Math.Max(1, (int)duration.TotalMinutes);
+            durationText = $"{mins} minute{(mins == 1 ? "" : "s")}";
+        }
+
+        var leaderboard = sightings
+            .Where(s => s.UserId != 0)
+            .GroupBy(s => s.UserId)
+            .OrderByDescending(g => g.Count())
+            .Select((g, i) =>
+            {
+                var spotterName = g.Select(s => s.UserName)
+                    .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? "Unknown";
+                var medal = i switch { 0 => "🥇", 1 => "🥈", 2 => "🥉", _ => $"   {i + 1}." };
+                return $"{medal} {System.Net.WebUtility.HtmlEncode(spotterName)} — {g.Count()} state{(g.Count() == 1 ? "" : "s")}";
+            })
+            .ToList();
+
+        var allStatesList = string.Join("  ", AllStates.OrderBy(s => s));
+        var startedAt = state.StartedAt.ToString("MMM d, yyyy");
+        var tripName = System.Net.WebUtility.HtmlEncode(state.TripName);
+
+        var msg =
+            "🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨\n\n" +
+            "🏆 <b>ALL 50 STATES COLLECTED!</b> 🏆\n\n" +
+            "🌟🌟🌟 <b>LEGENDARY ACHIEVEMENT UNLOCKED!</b> 🌟🌟🌟\n\n" +
+            "You and your crew have spotted license plates from every single US state — " +
+            "from the frozen tundra of <b>Alaska</b> to the tropical shores of <b>Hawaii</b>, " +
+            "from the mighty coasts of <b>California</b> to the historic streets of <b>Maine</b>! " +
+            "You've conquered all 50! 🇺🇸\n\n" +
+            "━━━━━━━━━━━━━━━━━━━━━━\n" +
+            $"🗺️ <b>TRIP: {tripName}</b>\n" +
+            $"📅 Started: {startedAt}\n" +
+            $"⏱️ Duration: {durationText}\n" +
+            "🏁 Final score: <b>50 / 50 states</b>\n" +
+            "━━━━━━━━━━━━━━━━━━━━━━";
+
+        if (leaderboard.Count > 0)
+        {
+            msg += "\n\n🏆 <b>FINAL LEADERBOARD:</b>\n" + string.Join("\n", leaderboard);
+        }
+
+        msg +=
+            $"\n\n🗺️ <b>ALL 50 STATES SPOTTED:</b>\n{allStatesList}\n\n" +
+            "🎉🥳🎊 <b>CONGRATULATIONS, ROAD TRIP LEGENDS!</b> 🎊🥳🎉\n\n" +
+            "🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨";
+
+        await _bot.SendMessage(chatId, msg, parseMode: ParseMode.Html);
     }
 
     private static string DisplayName(Telegram.Bot.Types.User? user)

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -173,7 +173,7 @@ public class BotCommandHandler
         var existing = sightings.FirstOrDefault(s => s.State.Equals(abbr, StringComparison.OrdinalIgnoreCase));
         if (existing is not null)
         {
-            var spotter = existing.UserName is { Length: > 0 } name ? $" — spotted by {name}" : "";
+            var spotter = existing.UserName is { Length: > 0 } name ? $" — spotted by {System.Net.WebUtility.HtmlEncode(name)}" : "";
             return $"👀 Already got <b>{StateNames[abbr]}</b> ({abbr}){spotter}! That's {sightings.Count}/50.";
         }
 
@@ -183,7 +183,7 @@ public class BotCommandHandler
         await _stateService.SaveAsync(state);
 
         var remaining = 50 - sightings.Count;
-        var credit = displayName is { Length: > 0 } ? $" by {displayName}" : "";
+        var credit = displayName is { Length: > 0 } ? $" by {System.Net.WebUtility.HtmlEncode(displayName)}" : "";
 
         if (sightings.Count == 50)
         {
@@ -228,7 +228,7 @@ public class BotCommandHandler
             })
             .ToList();
 
-        var allStatesList = string.Join("  ", AllStates.OrderBy(s => s));
+        var allStatesList = string.Join(", ", AllStates.OrderBy(s => s));
         var startedAt = state.StartedAt.ToString("MMM d, yyyy");
         var tripName = System.Net.WebUtility.HtmlEncode(state.TripName);
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A Telegram bot for playing the license plate game on road trips. Track which US 
 
 ## Features
 
-- `/saw CA` or `/saw California` — log a state you spotted; the bot credits you by name and notes if someone already got it
+- `/saw CA` or `/saw California` — log a state you spotted; the bot credits you by name and notes if someone already got it. When you collect the 50th state, the bot sends an elaborate celebration with trip stats, duration, and a final leaderboard
 - `/status` — see your progress with a visual progress bar and a per-player leaderboard
 - `/missing` — see which states you still need
 - `/undo` — remove the last logged state


### PR DESCRIPTION
When the 50th US state is logged, the bot now sends a dedicated
celebration message featuring firework emojis, trip name, duration,
a per-player final leaderboard with gold/silver/bronze medals, and
a complete list of all 50 spotted states — before the normal
confirmation message.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>