### PR TITLE
Add /skip command to exclude states from game completion

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -76,7 +76,7 @@ public class BotCommandHandler
         if (isCommand)
         {
             // Clear any pending conversational state when a new command arrives
-            if (command != "/saw" && command != "/skip")
+            if (command != "/saw")
             {
                 var s = await _stateService.GetOrCreateAsync(chatId);
                 if (s.PendingCommand is not null)
@@ -164,7 +164,7 @@ public class BotCommandHandler
         var input = string.Join(" ", args);
         string abbr;
         if (AllStates.Contains(input))
-            abbr = input.ToUpper();
+            abbr = input.ToUpperInvariant();
         else if (StateNameToAbbr.TryGetValue(input, out var matched))
             abbr = matched;
         else
@@ -216,7 +216,7 @@ public class BotCommandHandler
         var input = string.Join(" ", args);
         string abbr;
         if (AllStates.Contains(input))
-            abbr = input.ToUpper();
+            abbr = input.ToUpperInvariant();
         else if (StateNameToAbbr.TryGetValue(input, out var matched))
             abbr = matched;
         else
@@ -231,6 +231,9 @@ public class BotCommandHandler
 
         if (skipped.Any(s => s.Equals(abbr, StringComparison.OrdinalIgnoreCase)))
             return $"ℹ️ <b>{StateNames[abbr]}</b> ({abbr}) is already on the skip list.";
+
+        if (skipped.Count >= 50)
+            return "⚠️ You must keep at least one state required to complete the game.";
 
         skipped.Add(abbr);
         state.SkippedStatesJson = _stateService.SerializeSkippedStates(skipped);

--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -44,6 +44,7 @@ public class BotCommandHandler
     public static readonly Telegram.Bot.Types.BotCommand[] Commands =
     [
         new() { Command = "saw",      Description = "Log a state you spotted (e.g. /saw CA)" },
+        new() { Command = "skip",     Description = "Skip a state so it's not required to complete (e.g. /skip HI)" },
         new() { Command = "status",   Description = "See your current progress" },
         new() { Command = "missing",  Description = "See which states are still needed" },
         new() { Command = "undo",     Description = "Remove the last logged state" },
@@ -75,7 +76,7 @@ public class BotCommandHandler
         if (isCommand)
         {
             // Clear any pending conversational state when a new command arrives
-            if (command != "/saw")
+            if (command != "/saw" && command != "/skip")
             {
                 var s = await _stateService.GetOrCreateAsync(chatId);
                 if (s.PendingCommand is not null)
@@ -89,6 +90,7 @@ public class BotCommandHandler
             {
                 "/newtrip" or "/start" => await HandleNewTrip(chatId, args),
                 "/saw"                 => await HandleSaw(chatId, args, message.From),
+                "/skip"                => await HandleSkip(chatId, args),
                 "/status"              => await HandleStatus(chatId),
                 "/missing"             => await HandleMissing(chatId),
                 "/undo"                => await HandleUndo(chatId),
@@ -171,32 +173,74 @@ public class BotCommandHandler
         var state = await _stateService.GetOrCreateAsync(chatId);
         state.PendingCommand = null;
         var sightings = _stateService.DeserializeSightings(state.SeenStatesJson);
+        var skipped = _stateService.DeserializeSkippedStates(state.SkippedStatesJson);
 
         var existing = sightings.FirstOrDefault(s => s.State.Equals(abbr, StringComparison.OrdinalIgnoreCase));
         if (existing is not null)
         {
             var spotter = existing.UserName is { Length: > 0 } name ? $" — spotted by {System.Net.WebUtility.HtmlEncode(name)}" : "";
-            return $"👀 Already got <b>{StateNames[abbr]}</b> ({abbr}){spotter}! That's {sightings.Count}/51.";
+            var currentTarget = 51 - skipped.Count;
+            return $"👀 Already got <b>{StateNames[abbr]}</b> ({abbr}){spotter}! That's {sightings.Count}/{currentTarget}.";
         }
+
+        // If the state was skipped, automatically un-skip it when the player logs it
+        var skippedEntry = skipped.FirstOrDefault(s => s.Equals(abbr, StringComparison.OrdinalIgnoreCase));
+        var wasSkipped = skippedEntry is not null;
+        if (wasSkipped) skipped.Remove(skippedEntry!);
 
         var displayName = DisplayName(from);
         sightings.Add(new SightingRecord(abbr, from?.Id ?? 0, displayName));
         state.SeenStatesJson = _stateService.SerializeSightings(sightings);
+        state.SkippedStatesJson = _stateService.SerializeSkippedStates(skipped);
         await _stateService.SaveAsync(state);
 
-        var remaining = 51 - sightings.Count;
+        var target = 51 - skipped.Count;
+        var remaining = target - sightings.Count;
         var credit = displayName is { Length: > 0 } ? $" by {System.Net.WebUtility.HtmlEncode(displayName)}" : "";
+        var unskipNote = wasSkipped ? " (removed from skip list)" : "";
 
-        if (sightings.Count == 51)
+        if (sightings.Count == target)
         {
-            await SendAllStatesFoundCelebrationAsync(chatId, state, sightings);
-            return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!\n🏁 <b>51/51 — COMPLETE!</b> 🎆";
+            await SendAllStatesFoundCelebrationAsync(chatId, state, sightings, skipped);
+            return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!{unskipNote}\n🏁 <b>{target}/{target} — COMPLETE!</b> 🎆";
         }
 
-        return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!\n{sightings.Count}/51 plates found — {remaining} to go.";
+        return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!{unskipNote}\n{sightings.Count}/{target} plates found — {remaining} to go.";
     }
 
-    private async Task SendAllStatesFoundCelebrationAsync(long chatId, TripState state, List<SightingRecord> sightings)
+    private async Task<string> HandleSkip(long chatId, string[] args)
+    {
+        if (args.Length == 0)
+            return "Usage: /skip CA — specify a state abbreviation or full name to skip.";
+
+        var input = string.Join(" ", args);
+        string abbr;
+        if (AllStates.Contains(input))
+            abbr = input.ToUpper();
+        else if (StateNameToAbbr.TryGetValue(input, out var matched))
+            abbr = matched;
+        else
+            return $"❓ <b>{System.Net.WebUtility.HtmlEncode(input)}</b> isn't a recognized US state. Use a 2-letter abbreviation (HI) or full name (Hawaii).";
+
+        var state = await _stateService.GetOrCreateAsync(chatId);
+        var sightings = _stateService.DeserializeSightings(state.SeenStatesJson);
+        var skipped = _stateService.DeserializeSkippedStates(state.SkippedStatesJson);
+
+        if (sightings.Any(s => s.State.Equals(abbr, StringComparison.OrdinalIgnoreCase)))
+            return $"❓ You've already spotted <b>{StateNames[abbr]}</b> ({abbr}) — can't skip a state you've already found.";
+
+        if (skipped.Any(s => s.Equals(abbr, StringComparison.OrdinalIgnoreCase)))
+            return $"ℹ️ <b>{StateNames[abbr]}</b> ({abbr}) is already on the skip list.";
+
+        skipped.Add(abbr);
+        state.SkippedStatesJson = _stateService.SerializeSkippedStates(skipped);
+        await _stateService.SaveAsync(state);
+
+        var target = 51 - skipped.Count;
+        return $"⏭️ <b>{StateNames[abbr]}</b> ({abbr}) skipped. You now need {target} plates to complete the game.";
+    }
+
+    private async Task SendAllStatesFoundCelebrationAsync(long chatId, TripState state, List<SightingRecord> sightings, List<string> skippedStates)
     {
         var duration = DateTimeOffset.UtcNow - state.StartedAt;
         string durationText;
@@ -230,23 +274,22 @@ public class BotCommandHandler
             })
             .ToList();
 
-        var allStatesList = string.Join(", ", AllStates.OrderBy(s => s));
+        var target = 51 - skippedStates.Count;
+        var foundStatesList = string.Join(", ", sightings.Select(s => s.State).OrderBy(s => s));
         var startedAt = state.StartedAt.ToString("MMM d, yyyy");
         var tripName = System.Net.WebUtility.HtmlEncode(state.TripName);
 
         var msg =
             "🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨\n\n" +
-            "🏆 <b>ALL 51 PLATES COLLECTED!</b> 🏆\n\n" +
+            $"🏆 <b>ALL {target} PLATES COLLECTED!</b> 🏆\n\n" +
             "🌟🌟🌟 <b>LEGENDARY ACHIEVEMENT UNLOCKED!</b> 🌟🌟🌟\n\n" +
-            "You and your crew have spotted license plates from every single US state — " +
-            "from the frozen tundra of <b>Alaska</b> to the tropical shores of <b>Hawaii</b>, " +
-            "from the mighty coasts of <b>California</b> to the historic streets of <b>Maine</b>! " +
-            "You've conquered all 51! 🇺🇸\n\n" +
+            $"You and your crew have spotted license plates from all {target} required states! " +
+            "You've conquered every plate on your list! 🇺🇸\n\n" +
             "━━━━━━━━━━━━━━━━━━━━━━\n" +
             $"🗺️ <b>TRIP: {tripName}</b>\n" +
             $"📅 Started: {startedAt}\n" +
             $"⏱️ Duration: {durationText}\n" +
-            "🏁 Final score: <b>51 / 51 plates</b>\n" +
+            $"🏁 Final score: <b>{target} / {target} plates</b>\n" +
             "━━━━━━━━━━━━━━━━━━━━━━";
 
         if (leaderboard.Count > 0)
@@ -255,7 +298,7 @@ public class BotCommandHandler
         }
 
         msg +=
-            $"\n\n🗺️ <b>ALL 51 PLATES SPOTTED:</b>\n{allStatesList}\n\n" +
+            $"\n\n🗺️ <b>ALL {target} PLATES SPOTTED:</b>\n{foundStatesList}\n\n" +
             "🎉🥳🎊 <b>CONGRATULATIONS, ROAD TRIP LEGENDS!</b> 🎊🥳🎉\n\n" +
             "🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨";
 
@@ -273,18 +316,25 @@ public class BotCommandHandler
     {
         var state = await _stateService.GetOrCreateAsync(chatId);
         var sightings = _stateService.DeserializeSightings(state.SeenStatesJson);
+        var skipped = _stateService.DeserializeSkippedStates(state.SkippedStatesJson);
 
-        if (sightings.Count == 0)
+        if (sightings.Count == 0 && skipped.Count == 0)
             return "No plates logged yet! Use /saw CA to log your first one.";
 
-        var stateList = string.Join(", ", sightings.Select(s => s.State).OrderBy(s => s));
-        var bar = BuildProgressBar(sightings.Count, 51);
+        var target = 51 - skipped.Count;
+        var stateList = sightings.Count > 0
+            ? string.Join(", ", sightings.Select(s => s.State).OrderBy(s => s))
+            : "none yet";
+        var bar = BuildProgressBar(sightings.Count, target);
 
         var startedAt = state.StartedAt.ToString("MMM d, yyyy 'at' h:mm tt UTC");
         var result = $"🗺 <b>{System.Net.WebUtility.HtmlEncode(state.TripName)}</b>\n" +
                      $"Started: {startedAt}\n" +
-                     $"{bar} {sightings.Count}/51\n\n" +
+                     $"{bar} {sightings.Count}/{target}\n\n" +
                      $"<b>Found:</b> {stateList}";
+
+        if (skipped.Count > 0)
+            result += $"\n<b>Skipped:</b> {string.Join(", ", skipped.OrderBy(s => s))}";
 
         var leaderboard = sightings
             .Where(s => s.UserId != 0)
@@ -309,15 +359,18 @@ public class BotCommandHandler
     {
         var state = await _stateService.GetOrCreateAsync(chatId);
         var sightings = _stateService.DeserializeSightings(state.SeenStatesJson);
-        var seenAbbrs = sightings.Select(s => s.State).ToHashSet(StringComparer.OrdinalIgnoreCase);
+        var skipped = _stateService.DeserializeSkippedStates(state.SkippedStatesJson);
+        var seenOrSkipped = sightings.Select(s => s.State)
+            .Concat(skipped)
+            .ToHashSet(StringComparer.OrdinalIgnoreCase);
 
         var missing = AllStates
-            .Where(s => !seenAbbrs.Contains(s))
+            .Where(s => !seenOrSkipped.Contains(s))
             .OrderBy(s => s)
             .ToList();
 
         if (missing.Count == 0)
-            return "🎉 You've found all 51 plates! Nothing missing!";
+            return "🎉 You've found all required plates! Nothing missing!";
 
         var list = string.Join(", ", missing);
         return $"🔍 <b>{missing.Count} states still needed:</b>\n{list}";
@@ -327,6 +380,7 @@ public class BotCommandHandler
     {
         var state = await _stateService.GetOrCreateAsync(chatId);
         var sightings = _stateService.DeserializeSightings(state.SeenStatesJson);
+        var skipped = _stateService.DeserializeSkippedStates(state.SkippedStatesJson);
 
         if (sightings.Count == 0)
             return "Nothing to undo — no states logged yet.";
@@ -336,7 +390,8 @@ public class BotCommandHandler
         state.SeenStatesJson = _stateService.SerializeSightings(sightings);
         await _stateService.SaveAsync(state);
 
-        return $"↩️ Removed <b>{StateNames[removed.State]}</b> ({removed.State}). Back to {sightings.Count}/51.";
+        var target = 51 - skipped.Count;
+        return $"↩️ Removed <b>{StateNames[removed.State]}</b> ({removed.State}). Back to {sightings.Count}/{target}.";
     }
 
     private async Task<string> HandleHistory(long chatId)
@@ -348,6 +403,8 @@ public class BotCommandHandler
         var lines = history.Take(25).Select((t, i) =>
         {
             var sightings = _stateService.DeserializeSightings(t.SeenStatesJson);
+            var skipped = _stateService.DeserializeSkippedStates(t.SkippedStatesJson);
+            var tripTarget = 51 - skipped.Count;
             var date = t.StartedAt.ToString("MMM d, yyyy");
             var name = System.Net.WebUtility.HtmlEncode(t.TripName);
             var topSpotter = sightings
@@ -357,7 +414,8 @@ public class BotCommandHandler
                 .Select(g => g.Select(s => s.UserName).FirstOrDefault(userName => !string.IsNullOrEmpty(userName)) ?? "Unknown")
                 .FirstOrDefault();
             var mvp = topSpotter is not null ? $" 🏆 {System.Net.WebUtility.HtmlEncode(topSpotter)}" : "";
-            return $"{i + 1}. <b>{name}</b> ({date}) — {sightings.Count}/51 plates{mvp}";
+            var skippedNote = skipped.Count > 0 ? $" (skipped: {string.Join(", ", skipped.OrderBy(s => s))})" : "";
+            return $"{i + 1}. <b>{name}</b> ({date}) — {sightings.Count}/{tripTarget} plates{mvp}{skippedNote}";
         });
 
         return "📋 <b>Trip History</b>\n\n" + string.Join("\n", lines);
@@ -366,6 +424,7 @@ public class BotCommandHandler
     private static string GetHelp() =>
         "<b>License Plate Game 🚗</b>\n\n" +
         "/saw CA — log a state you spotted (abbreviation or full name)\n" +
+        "/skip HI — skip a state so it's not required to complete the game\n" +
         "/status — see your progress\n" +
         "/missing — see what's left\n" +
         "/undo — remove the last logged state\n" +

--- a/README.md
+++ b/README.md
@@ -4,12 +4,13 @@ A Telegram bot for playing the license plate game on road trips. Track which US 
 
 ## Features
 
-- `/saw CA` or `/saw California` or `/saw DC` — log a state you spotted; the bot credits you by name and notes if someone already got it. When you collect the 51st plate, the bot sends an elaborate celebration with trip stats, duration, and a final leaderboard
-- `/status` — see your progress with a visual progress bar and a per-player leaderboard
-- `/missing` — see which states you still need
+- `/saw CA` or `/saw California` or `/saw DC` — log a state you spotted; the bot credits you by name and notes if someone already got it. When you collect all required plates, the bot sends an elaborate celebration with trip stats, duration, and a final leaderboard
+- `/skip HI` — remove a state from the required list so it doesn't block completion; skipped states appear in `/status` and are noted in `/history`
+- `/status` — see your progress with a visual progress bar and a per-player leaderboard; lists any skipped states
+- `/missing` — see which states you still need (excludes skipped states)
 - `/undo` — remove the last logged state
 - `/newtrip [name]` — start fresh for a new trip; if no name is given, the bot asks for one (default: `Road Trip MM/DD/YYYY`)
-- `/history` — view results from all previous trips, including the top spotter for each
+- `/history` — view results from all previous trips, including the top spotter and any skipped states for each
 
 State is stored per Telegram chat, so any member of a group chat can log plates and everyone sees the updates in real time.
 
@@ -229,11 +230,12 @@ Both you and your chat partner can now send commands and see each other's update
 | Command | Description | Example |
 |---|---|---|
 | `/saw [state]` | Log a state you spotted by abbreviation or full name (including DC); credits you by name; omit the state and the bot will prompt you | `/saw CA` or `/saw California` or `/saw DC` |
-| `/status` | Show progress, states found, and a per-player leaderboard | `/status` |
-| `/missing` | List states not yet found | `/missing` |
+| `/skip [state]` | Remove a state from the required list so it doesn't block completion; logging a skipped state later automatically un-skips it | `/skip HI` or `/skip Hawaii` |
+| `/status` | Show progress, states found, skipped states, and a per-player leaderboard | `/status` |
+| `/missing` | List states not yet found (excludes skipped states) | `/missing` |
 | `/undo` | Remove the last logged state | `/undo` |
 | `/newtrip [name]` | Start a fresh trip; if no name is given, the bot asks for one (default: `Road Trip MM/DD/YYYY`); current trip is saved to history if any states were logged | `/newtrip Colorado 2026` |
-| `/history` | Show results from all previous trips in this chat | `/history` |
+| `/history` | Show results from all previous trips in this chat, including any skipped states | `/history` |
 | `/help` | Show command reference | `/help` |
 
 ---

--- a/TripState.cs
+++ b/TripState.cs
@@ -18,4 +18,5 @@ public class TripState : ITableEntity
     public DateTimeOffset StartedAt { get; set; } = DateTimeOffset.UtcNow;
     public string? PendingCommand { get; set; }  // conversational state, e.g. "saw"
     public DateTimeOffset? EndedAt { get; set; }  // set when trip is archived
+    public string SkippedStatesJson { get; set; } = "[]";  // JSON array of skipped state abbreviations
 }

--- a/TripStateService.cs
+++ b/TripStateService.cs
@@ -40,12 +40,13 @@ public class TripStateService
 
     public async Task ResetAsync(long chatId, string tripName)
     {
-        // Archive current trip if it has any states logged
+        // Archive current trip if it has any states logged or any states skipped
         try
         {
             var response = await _tableClient.GetEntityAsync<TripState>(chatId.ToString(), "currentTrip");
             var existing = response.Value;
-            if (DeserializeSightings(existing.SeenStatesJson).Count > 0)
+            if (DeserializeSightings(existing.SeenStatesJson).Count > 0 ||
+                DeserializeSkippedStates(existing.SkippedStatesJson).Count > 0)
             {
                 var archived = new TripState
                 {

--- a/TripStateService.cs
+++ b/TripStateService.cs
@@ -53,6 +53,7 @@ public class TripStateService
                     RowKey = $"trip_{existing.StartedAt:yyyyMMddHHmmss}",
                     TripName = existing.TripName,
                     SeenStatesJson = existing.SeenStatesJson,
+                    SkippedStatesJson = existing.SkippedStatesJson,
                     StartedAt = existing.StartedAt,
                     EndedAt = DateTimeOffset.UtcNow
                 };
@@ -101,4 +102,20 @@ public class TripStateService
 
     public string SerializeSightings(List<SightingRecord> sightings) =>
         JsonSerializer.Serialize(sightings);
+
+    public List<string> DeserializeSkippedStates(string? json)
+    {
+        if (string.IsNullOrEmpty(json) || json == "[]") return [];
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(json) ?? [];
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    public string SerializeSkippedStates(List<string> states) =>
+        JsonSerializer.Serialize(states);
 }


### PR DESCRIPTION
- New /skip <state> command removes a state from the required list so it
  does not block reaching "complete" (e.g. /skip HI drops target from 51 to 50)
- /status shows the adjusted target count and lists skipped states
- /missing excludes skipped states from the "still needed" list
- /history notes which states were skipped for each archived trip
- Logging a skipped state via /saw automatically un-skips it
- Celebration message and progress counts are all target-aware
- Added SkippedStatesJson column to TripState; archived when starting a new trip

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>