### PR TITLE
Add /skip command to exclude states from game completion

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -76,7 +76,7 @@ public class BotCommandHandler
         if (isCommand)
         {
             // Clear any pending conversational state when a new command arrives
-            if (command != "/saw")
+            if (command != "/saw" && command != "/skip")
             {
                 var s = await _stateService.GetOrCreateAsync(chatId);
                 if (s.PendingCommand is not null)
@@ -108,6 +108,12 @@ public class BotCommandHandler
                 state.PendingCommand = null;
                 await _stateService.SaveAsync(state);
                 reply = await HandleSaw(chatId, parts, message.From);
+            }
+            else if (state.PendingCommand == "skip")
+            {
+                state.PendingCommand = null;
+                await _stateService.SaveAsync(state);
+                reply = await HandleSkip(chatId, parts);
             }
             else if (state.PendingCommand is { } pc && pc.StartsWith("newtrip:", StringComparison.Ordinal))
             {
@@ -208,10 +214,18 @@ public class BotCommandHandler
         return $"✅ <b>{StateNames[abbr]}</b> ({abbr}) spotted{credit}!{unskipNote}\n{sightings.Count}/{target} plates found — {remaining} to go.";
     }
 
-    private async Task<string> HandleSkip(long chatId, string[] args)
+    private async Task<string?> HandleSkip(long chatId, string[] args)
     {
         if (args.Length == 0)
-            return "Usage: /skip CA — specify a state abbreviation or full name to skip.";
+        {
+            var pending = await _stateService.GetOrCreateAsync(chatId);
+            pending.PendingCommand = "skip";
+            await _stateService.SaveAsync(pending);
+            await _bot.SendMessage(chatId,
+                "Which state do you want to skip? Reply with the 2-letter abbreviation or full name (e.g. HI, Hawaii).",
+                replyMarkup: new ForceReplyMarkup());
+            return null;
+        }
 
         var input = string.Join(" ", args);
         string abbr;
@@ -223,6 +237,7 @@ public class BotCommandHandler
             return $"❓ <b>{System.Net.WebUtility.HtmlEncode(input)}</b> isn't a recognized US state. Use a 2-letter abbreviation (HI) or full name (Hawaii).";
 
         var state = await _stateService.GetOrCreateAsync(chatId);
+        state.PendingCommand = null;
         var sightings = _stateService.DeserializeSightings(state.SeenStatesJson);
         var skipped = _stateService.DeserializeSkippedStates(state.SkippedStatesJson);
 


### PR DESCRIPTION
Closes #26

## Summary

- **New `/skip [state]` command** — removes a state from the required list so it doesn't block completion (e.g. `/skip HI` drops the target from 51 to 50). Like `/saw`, calling `/skip` with no argument prompts for a reply.
- **`/status`** — shows the adjusted target count and lists any skipped states.
- **`/missing`** — excludes skipped states from the "still needed" list.
- **`/history`** — notes which states were skipped for each archived trip.
- **Completion logic** — the game completes at `51 - skipped.Count` plates; the celebration message and all progress counts are target-aware.
- **Auto-unskip** — logging a skipped state via `/saw` automatically removes it from the skip list.
- **Storage** — added `SkippedStatesJson` column to `TripState`; archived correctly on `/newtrip` (including trips where states were skipped but none were seen).

## Test plan

- [ ] `/skip HI` — bot confirms Hawaii skipped, reports new target (50)
- [ ] `/skip` (no arg) — bot prompts for a state with ForceReplyMarkup; reply with `HI` skips it
- [ ] `/skip HI` twice — second call returns "already on the skip list"
- [ ] `/saw HI` after skipping HI — logs the plate and removes HI from the skip list
- [ ] `/skip CA` after `/saw CA` — returns error "can't skip a state you've already found"
- [ ] `/status` — shows `X/50` progress bar and `Skipped: HI` line
- [ ] `/missing` — HI absent from the list
- [ ] Collect all non-skipped plates — game completes and celebration fires correctly
- [ ] `/newtrip` after skipping (no plates seen) — previous trip is archived with skip info
- [ ] `/history` — archived trips show `(skipped: HI)` note

---
_Generated by [Claude Code](https://claude.ai/code/session_017bZXDZJ9vCBtNCN9sHQqNS)_