### PR TITLE
Add admin broadcast: HTTP trigger + /broadcast Telegram command (issue #32)

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -1,4 +1,5 @@
 using LicensePlateBot.Models;
+using Microsoft.Extensions.Configuration;
 using Telegram.Bot;
 using Telegram.Bot.Types;
 using Telegram.Bot.Types.Enums;
@@ -8,6 +9,7 @@ public class BotCommandHandler
 {
     private readonly ITelegramBotClient _bot;
     private readonly TripStateService _stateService;
+    private readonly long? _adminUserId;
 
     // All 50 US states plus DC
     private static readonly HashSet<string> AllStates = new(StringComparer.OrdinalIgnoreCase)
@@ -53,10 +55,11 @@ public class BotCommandHandler
         new() { Command = "help",     Description = "Show available commands" },
     ];
 
-    public BotCommandHandler(ITelegramBotClient bot, TripStateService stateService)
+    public BotCommandHandler(ITelegramBotClient bot, TripStateService stateService, IConfiguration config)
     {
         _bot = bot;
         _stateService = stateService;
+        _adminUserId = long.TryParse(config["AdminTelegramUserId"], out var id) ? id : null;
     }
 
     public async Task HandleUpdateAsync(Update update)
@@ -96,6 +99,7 @@ public class BotCommandHandler
                 "/undo"                => await HandleUndo(chatId),
                 "/history"             => await HandleHistory(chatId),
                 "/help"                => GetHelp(),
+                "/broadcast"           => await HandleBroadcast(chatId, args, message.From),
                 _                      => null
             };
         }
@@ -454,5 +458,48 @@ public class BotCommandHandler
     {
         var filled = (int)Math.Round((double)current / total * 10);
         return "[" + new string('█', filled) + new string('░', 10 - filled) + "]";
+    }
+
+    private async Task<string?> HandleBroadcast(long chatId, string[] args, Telegram.Bot.Types.User? from)
+    {
+        // Silently ignore non-admins
+        if (_adminUserId is null || from?.Id != _adminUserId)
+            return null;
+
+        if (args.Length == 0)
+            return "Usage: /broadcast &lt;message&gt;\n       /broadcast &lt;chatId&gt; &lt;message&gt;";
+
+        // If the first arg looks like a chat ID, target that chat only
+        long? targetChatId = null;
+        string[] messageArgs = args;
+        if (args.Length > 1 && long.TryParse(args[0], out var parsedId))
+        {
+            targetChatId = parsedId;
+            messageArgs = args[1..];
+        }
+
+        var text = string.Join(" ", messageArgs);
+        if (string.IsNullOrWhiteSpace(text))
+            return "Usage: /broadcast &lt;message&gt;\n       /broadcast &lt;chatId&gt; &lt;message&gt;";
+
+        var chatIds = targetChatId.HasValue
+            ? new List<long> { targetChatId.Value }
+            : await _stateService.GetAllChatIdsAsync();
+
+        int sent = 0, failed = 0;
+        foreach (var id in chatIds)
+        {
+            try
+            {
+                await _bot.SendMessage(id, text);
+                sent++;
+            }
+            catch
+            {
+                failed++;
+            }
+        }
+
+        return $"📣 Broadcast sent: {sent} delivered, {failed} failed ({chatIds.Count} total).";
     }
 }

--- a/BroadcastFunction.cs
+++ b/BroadcastFunction.cs
@@ -1,0 +1,73 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Extensions.Logging;
+using System.Net;
+using System.Text.Json;
+using Telegram.Bot;
+
+public class BroadcastFunction
+{
+    private static readonly JsonSerializerOptions JsonOptions = new() { PropertyNameCaseInsensitive = true };
+
+    private readonly ITelegramBotClient _bot;
+    private readonly TripStateService _stateService;
+    private readonly ILogger<BroadcastFunction> _logger;
+
+    public BroadcastFunction(ITelegramBotClient bot, TripStateService stateService, ILogger<BroadcastFunction> logger)
+    {
+        _bot = bot;
+        _stateService = stateService;
+        _logger = logger;
+    }
+
+    [Function("Broadcast")]
+    public async Task<HttpResponseData> Run(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "broadcast")] HttpRequestData req)
+    {
+        var body = await req.ReadAsStringAsync();
+        if (string.IsNullOrWhiteSpace(body))
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+
+        BroadcastRequest? request;
+        try
+        {
+            request = JsonSerializer.Deserialize<BroadcastRequest>(body, JsonOptions);
+        }
+        catch
+        {
+            return req.CreateResponse(HttpStatusCode.BadRequest);
+        }
+
+        if (request is null || string.IsNullOrWhiteSpace(request.Message))
+        {
+            var bad = req.CreateResponse(HttpStatusCode.BadRequest);
+            await bad.WriteStringAsync("'message' is required.");
+            return bad;
+        }
+
+        List<long> chatIds = request.ChatId.HasValue
+            ? [request.ChatId.Value]
+            : await _stateService.GetAllChatIdsAsync();
+
+        int sent = 0, failed = 0;
+        foreach (var chatId in chatIds)
+        {
+            try
+            {
+                await _bot.SendMessage(chatId, request.Message);
+                sent++;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Broadcast failed for chat {ChatId}", chatId);
+                failed++;
+            }
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        await response.WriteAsJsonAsync(new { sent, failed, total = chatIds.Count });
+        return response;
+    }
+}
+
+public record BroadcastRequest(string Message, long? ChatId);

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A Telegram bot for playing the license plate game on road trips. Track which US 
 - `/undo` — remove the last logged state
 - `/newtrip [name]` — start fresh for a new trip; if no name is given, the bot asks for one (default: `Road Trip MM/DD/YYYY`)
 - `/history` — view results from all previous trips, including the top spotter and any skipped states for each
+- **Admin broadcast** — send a plain-text message to all active game chats, or to a specific chat, via an HTTP trigger or the `/broadcast` Telegram command (admin-only)
 
 State is stored per Telegram chat, so any member of a group chat can log plates and everyone sees the updates in real time.
 
@@ -58,7 +59,8 @@ Edit `local.settings.json` and fill in your bot token:
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
     "FUNCTIONS_WORKER_RUNTIME": "dotnet-isolated",
     "TelegramBotToken": "<YOUR_BOT_TOKEN>",
-    "StorageConnectionString": "UseDevelopmentStorage=true"
+    "StorageConnectionString": "UseDevelopmentStorage=true",
+    "AdminTelegramUserId": "<YOUR_TELEGRAM_USER_ID>"
   }
 }
 ```
@@ -156,7 +158,8 @@ az functionapp config appsettings set \
   --resource-group rg-licenseplate-bot \
   --settings \
     TelegramBotToken="<YOUR_BOT_TOKEN>" \
-    StorageConnectionString="<YOUR_CONNECTION_STRING>"
+    StorageConnectionString="<YOUR_CONNECTION_STRING>" \
+    AdminTelegramUserId="<YOUR_TELEGRAM_USER_ID>"
 ```
 
 ### 4. Deploy
@@ -225,6 +228,45 @@ Both you and your chat partner can now send commands and see each other's update
 
 ---
 
+## Admin Broadcast
+
+As an admin you can push a plain-text message to all active game chats, or to a specific chat, via two mechanisms.
+
+### 1. HTTP trigger
+
+`POST /api/broadcast` — secured by the Azure Function host key.
+
+```bash
+# Broadcast to all active chats
+curl -X POST "https://func-licenseplate-bot.azurewebsites.net/api/broadcast?code=<FUNCTION_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "We are doing maintenance at midnight — save your progress!"}'
+
+# Broadcast to a specific chat
+curl -X POST "https://func-licenseplate-bot.azurewebsites.net/api/broadcast?code=<FUNCTION_KEY>" \
+  -H "Content-Type: application/json" \
+  -d '{"message": "Hey, your trip data was migrated.", "chatId": -1001234567890}'
+```
+
+Response: `{ "sent": 3, "failed": 0, "total": 3 }`
+
+For local testing replace the URL with `http://localhost:7071/api/broadcast` (no `?code=` needed in dev).
+
+### 2. Telegram `/broadcast` command
+
+Send the command from your own Telegram account (the one whose user ID is set in `AdminTelegramUserId`).
+
+```
+/broadcast Hello everyone, enjoy the trip!
+/broadcast -1001234567890 Hey, just this one chat.
+```
+
+The bot replies with a delivery summary visible only in your chat. Non-admins get no response.
+
+To find your Telegram user ID, message [@userinfobot](https://t.me/userinfobot).
+
+---
+
 ## Bot Commands Reference
 
 | Command | Description | Example |
@@ -252,6 +294,7 @@ LicensePlateBot/
 ├── local.settings.json      # Local dev secrets (gitignored)
 ├── Program.cs               # Host builder and DI wiring
 ├── TelegramFunction.cs      # HTTP trigger — receives webhook POSTs
+├── BroadcastFunction.cs     # HTTP trigger — admin broadcast endpoint
 ├── BotCommandHandler.cs     # Command routing and response logic
 ├── TripStateService.cs      # Azure Table Storage read/write
 └── Models/

--- a/TripStateService.cs
+++ b/TripStateService.cs
@@ -73,6 +73,21 @@ public class TripStateService
         await _tableClient.UpsertEntityAsync(state, TableUpdateMode.Replace);
     }
 
+    public async Task<List<long>> GetAllChatIdsAsync()
+    {
+        var chatIds = new List<long>();
+
+        await foreach (var entity in _tableClient.QueryAsync<TableEntity>(
+            filter: "RowKey eq 'currentTrip'",
+            select: ["PartitionKey"]))
+        {
+            if (long.TryParse(entity.PartitionKey, out var id))
+                chatIds.Add(id);
+        }
+
+        return chatIds;
+    }
+
     public async Task<List<TripState>> GetHistoryAsync(long chatId)
     {
         var partitionKey = chatId.ToString();


### PR DESCRIPTION
Two ways to send a plain-text message to all active game chats or a specific chat:

1. POST /api/broadcast (AuthorizationLevel.Function) — body: {"message":"...", "chatId":123}
   chatId is optional; omit to target all active chats. Returns {sent, failed, total}.

2. /broadcast <message> or /broadcast <chatId> <message> Telegram command —
   silently ignored for non-admins; admin is identified by AdminTelegramUserId app setting.

TripStateService gains GetAllChatIdsAsync() which queries all 'currentTrip' rows.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

https://claude.ai/code/session_01TFAnTaSCFh1ZZQdhQ8iPK4