### PR TITLE
Add rich message formatting for status, history, help, and celebration

### DIFF
--- a/BotCommandHandler.cs
+++ b/BotCommandHandler.cs
@@ -98,7 +98,7 @@ public class BotCommandHandler
                 "/missing"             => await HandleMissing(chatId),
                 "/undo"                => await HandleUndo(chatId),
                 "/history"             => await HandleHistory(chatId),
-                "/help"                => GetHelp(),
+                "/help"                => await HandleHelp(chatId),
                 "/broadcast"           => await HandleBroadcast(chatId, args, message.From),
                 _                      => null
             };
@@ -291,8 +291,8 @@ public class BotCommandHandler
             {
                 var spotterName = g.Select(s => s.UserName)
                     .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? "Unknown";
-                var medal = i switch { 0 => "🥇", 1 => "🥈", 2 => "🥉", _ => $"   {i + 1}." };
-                return $"{medal} {System.Net.WebUtility.HtmlEncode(spotterName)} — {g.Count()} state{(g.Count() == 1 ? "" : "s")}";
+                var medal = i switch { 0 => "🥇", 1 => "🥈", 2 => "🥉", _ => $"{i + 1}." };
+                return $"<tr><td>{medal}</td><td>{System.Net.WebUtility.HtmlEncode(spotterName)}</td><td>{g.Count()}</td></tr>";
             })
             .ToList();
 
@@ -301,30 +301,39 @@ public class BotCommandHandler
         var startedAt = state.StartedAt.ToString("MMM d, yyyy");
         var tripName = System.Net.WebUtility.HtmlEncode(state.TripName);
 
-        var msg =
-            "🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨\n\n" +
-            $"🏆 <b>ALL {target} PLATES COLLECTED!</b> 🏆\n\n" +
-            "🌟🌟🌟 <b>LEGENDARY ACHIEVEMENT UNLOCKED!</b> 🌟🌟🌟\n\n" +
-            $"You and your crew have spotted license plates from all {target} required states! " +
-            "You've conquered every plate on your list! 🇺🇸\n\n" +
-            "━━━━━━━━━━━━━━━━━━━━━━\n" +
-            $"🗺️ <b>TRIP: {tripName}</b>\n" +
-            $"📅 Started: {startedAt}\n" +
-            $"⏱️ Duration: {durationText}\n" +
-            $"🏁 Final score: <b>{target} / {target} plates</b>\n" +
-            "━━━━━━━━━━━━━━━━━━━━━━";
+        var html =
+            $"<h1>🏆 ALL {target} PLATES COLLECTED! 🏆</h1>" +
+            "<h2>🌟 LEGENDARY ACHIEVEMENT UNLOCKED! 🌟</h2>" +
+            $"<p>You and your crew have spotted license plates from all {target} required states! " +
+            "You've conquered every plate on your list! 🇺🇸</p>" +
+            $"<h3>🗺️ {tripName}</h3>" +
+            "<ul>" +
+            $"<li>📅 Started: {startedAt}</li>" +
+            $"<li>⏱️ Duration: {durationText}</li>" +
+            $"<li>🏁 Final score: <b>{target} / {target} plates</b></li>" +
+            "</ul>";
 
         if (leaderboard.Count > 0)
         {
-            msg += "\n\n🏆 <b>FINAL LEADERBOARD:</b>\n" + string.Join("\n", leaderboard);
+            html += "<h3>🏆 Final Leaderboard</h3><table>" +
+                    "<tr><th>#</th><th>Player</th><th>States</th></tr>" +
+                    string.Join("", leaderboard) +
+                    "</table>";
         }
 
-        msg +=
-            $"\n\n🗺️ <b>ALL {target} PLATES SPOTTED:</b>\n{foundStatesList}\n\n" +
-            "🎉🥳🎊 <b>CONGRATULATIONS, ROAD TRIP LEGENDS!</b> 🎊🥳🎉\n\n" +
-            "🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨🎆🎇✨";
+        html +=
+            $"<h3>🗺️ All {target} plates spotted</h3>" +
+            $"<p>{foundStatesList}</p>" +
+            "<h2>🎉 CONGRATULATIONS, ROAD TRIP LEGENDS! 🎉</h2>";
 
-        await _bot.SendMessage(chatId, msg, parseMode: ParseMode.Html);
+        await SendRichHtmlAsync(chatId, html);
+    }
+
+    // Sends a Telegram rich message (tables, headings, lists) via the Bot API's
+    // sendRichMessage method, introduced in Bot API 10.1.
+    private async Task SendRichHtmlAsync(long chatId, string html)
+    {
+        await _bot.SendRichMessage(chatId, new InputRichMessage { Html = html });
     }
 
     private static string DisplayName(Telegram.Bot.Types.User? user)
@@ -334,7 +343,7 @@ public class BotCommandHandler
         return name.Length > 0 ? name : user.Username ?? string.Empty;
     }
 
-    private async Task<string> HandleStatus(long chatId)
+    private async Task<string?> HandleStatus(long chatId)
     {
         var state = await _stateService.GetOrCreateAsync(chatId);
         var sightings = _stateService.DeserializeSightings(state.SeenStatesJson);
@@ -350,13 +359,13 @@ public class BotCommandHandler
         var bar = BuildProgressBar(sightings.Count, target);
 
         var startedAt = state.StartedAt.ToString("MMM d, yyyy 'at' h:mm tt UTC");
-        var result = $"🗺 <b>{System.Net.WebUtility.HtmlEncode(state.TripName)}</b>\n" +
-                     $"Started: {startedAt}\n" +
-                     $"{bar} {sightings.Count}/{target}\n\n" +
-                     $"<b>Found:</b> {stateList}";
+        var html = $"<h2>🗺 {System.Net.WebUtility.HtmlEncode(state.TripName)}</h2>" +
+                   $"<p>Started: {startedAt}</p>" +
+                   $"<p>{bar} {sightings.Count}/{target}</p>" +
+                   $"<p><b>Found:</b> {stateList}</p>";
 
         if (skipped.Count > 0)
-            result += $"\n<b>Skipped:</b> {string.Join(", ", skipped.OrderBy(s => s))}";
+            html += $"<p><b>Skipped:</b> {string.Join(", ", skipped.OrderBy(s => s))}</p>";
 
         var leaderboard = sightings
             .Where(s => s.UserId != 0)
@@ -366,15 +375,19 @@ public class BotCommandHandler
             {
                 var spotterName = g.Select(s => s.UserName)
                     .FirstOrDefault(name => !string.IsNullOrWhiteSpace(name)) ?? "Unknown";
-                return $"{System.Net.WebUtility.HtmlEncode(spotterName)} — {g.Count()}";
+                return (Name: System.Net.WebUtility.HtmlEncode(spotterName), Count: g.Count());
             })
             .ToList();
 
         if (leaderboard.Count > 0)
-            result += "\n\n<b>Leaderboard:</b>\n" +
-                      string.Join("\n", leaderboard.Select((line, i) => $"{i + 1}. {line}"));
+        {
+            html += "<h3>Leaderboard</h3><table><tr><th>#</th><th>Player</th><th>States</th></tr>" +
+                    string.Join("", leaderboard.Select((entry, i) => $"<tr><td>{i + 1}</td><td>{entry.Name}</td><td>{entry.Count}</td></tr>")) +
+                    "</table>";
+        }
 
-        return result;
+        await SendRichHtmlAsync(chatId, html);
+        return null;
     }
 
     private async Task<string> HandleMissing(long chatId)
@@ -416,13 +429,13 @@ public class BotCommandHandler
         return $"↩️ Removed <b>{StateNames[removed.State]}</b> ({removed.State}). Back to {sightings.Count}/{target}.";
     }
 
-    private async Task<string> HandleHistory(long chatId)
+    private async Task<string?> HandleHistory(long chatId)
     {
         var history = await _stateService.GetHistoryAsync(chatId);
         if (history.Count == 0)
             return "No previous trips yet. Start a new trip with /newtrip!";
 
-        var lines = history.Take(25).Select((t, i) =>
+        var rows = history.Take(25).Select((t, i) =>
         {
             var sightings = _stateService.DeserializeSightings(t.SeenStatesJson);
             var skipped = _stateService.DeserializeSkippedStates(t.SkippedStatesJson);
@@ -435,24 +448,36 @@ public class BotCommandHandler
                 .OrderByDescending(g => g.Count())
                 .Select(g => g.Select(s => s.UserName).FirstOrDefault(userName => !string.IsNullOrEmpty(userName)) ?? "Unknown")
                 .FirstOrDefault();
-            var mvp = topSpotter is not null ? $" 🏆 {System.Net.WebUtility.HtmlEncode(topSpotter)}" : "";
-            var skippedNote = skipped.Count > 0 ? $" (skipped: {string.Join(", ", skipped.OrderBy(s => s))})" : "";
-            return $"{i + 1}. <b>{name}</b> ({date}) — {sightings.Count}/{tripTarget} plates{mvp}{skippedNote}";
+            var mvp = topSpotter is not null ? $"🏆 {System.Net.WebUtility.HtmlEncode(topSpotter)}" : "—";
+            var skippedNote = skipped.Count > 0 ? string.Join(", ", skipped.OrderBy(s => s)) : "—";
+            return $"<tr><td>{i + 1}</td><td>{name}</td><td>{date}</td><td>{sightings.Count}/{tripTarget}</td><td>{mvp}</td><td>{skippedNote}</td></tr>";
         });
 
-        return "📋 <b>Trip History</b>\n\n" + string.Join("\n", lines);
+        var html = "<h2>📋 Trip History</h2><table>" +
+                   "<tr><th>#</th><th>Trip</th><th>Date</th><th>Score</th><th>MVP</th><th>Skipped</th></tr>" +
+                   string.Join("", rows) +
+                   "</table>";
+
+        await SendRichHtmlAsync(chatId, html);
+        return null;
     }
 
-    private static string GetHelp() =>
-        "<b>License Plate Game 🚗</b>\n\n" +
-        "/saw CA — log a state you spotted (abbreviation or full name)\n" +
-        "/skip HI — skip a state so it's not required to complete the game\n" +
-        "/status — see your progress\n" +
-        "/missing — see what's left\n" +
-        "/undo — remove the last logged state\n" +
-        "/newtrip [name] — start a fresh trip\n" +
-        "/history — view results from previous trips\n" +
-        "/help — show this message";
+    private async Task<string?> HandleHelp(long chatId)
+    {
+        var html = "<h2>License Plate Game 🚗</h2><ul>" +
+                   "<li><code>/saw CA</code> — log a state you spotted (abbreviation or full name)</li>" +
+                   "<li><code>/skip HI</code> — skip a state so it's not required to complete the game</li>" +
+                   "<li><code>/status</code> — see your progress</li>" +
+                   "<li><code>/missing</code> — see what's left</li>" +
+                   "<li><code>/undo</code> — remove the last logged state</li>" +
+                   "<li><code>/newtrip [name]</code> — start a fresh trip</li>" +
+                   "<li><code>/history</code> — view results from previous trips</li>" +
+                   "<li><code>/help</code> — show this message</li>" +
+                   "</ul>";
+
+        await SendRichHtmlAsync(chatId, html);
+        return null;
+    }
 
     private static string BuildProgressBar(int current, int total)
     {

--- a/LicensePlateBot.csproj
+++ b/LicensePlateBot.csproj
@@ -17,6 +17,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http" Version="3.2.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="1.17.4" />
     <PackageReference Include="Azure.Data.Tables" Version="12.9.0" />
-    <PackageReference Include="Telegram.Bot" Version="21.12.0" />
+    <PackageReference Include="Telegram.Bot" Version="22.10.1" />
   </ItemGroup>
 </Project>

--- a/README.md
+++ b/README.md
@@ -4,16 +4,18 @@ A Telegram bot for playing the license plate game on road trips. Track which US 
 
 ## Features
 
-- `/saw CA` or `/saw California` or `/saw DC` — log a state you spotted; the bot credits you by name and notes if someone already got it. When you collect all required plates, the bot sends an elaborate celebration with trip stats, duration, and a final leaderboard
+- `/saw CA` or `/saw California` or `/saw DC` — log a state you spotted; the bot credits you by name and notes if someone already got it. When you collect all required plates, the bot sends an elaborate celebration with trip stats, duration, and a final leaderboard table
 - `/skip HI` — remove a state from the required list so it doesn't block completion; skipped states appear in `/status` and are noted in `/history`
-- `/status` — see your progress with a visual progress bar and a per-player leaderboard; lists any skipped states
+- `/status` — see your progress with a visual progress bar and a per-player leaderboard table; lists any skipped states
 - `/missing` — see which states you still need (excludes skipped states)
 - `/undo` — remove the last logged state
 - `/newtrip [name]` — start fresh for a new trip; if no name is given, the bot asks for one (default: `Road Trip MM/DD/YYYY`)
-- `/history` — view results from all previous trips, including the top spotter and any skipped states for each
+- `/history` — view results from all previous trips as a table, including the top spotter and any skipped states for each
 - **Admin broadcast** — send a plain-text message to all active game chats, or to a specific chat, via an HTTP trigger or the `/broadcast` Telegram command (admin-only)
 
 State is stored per Telegram chat, so any member of a group chat can log plates and everyone sees the updates in real time.
+
+Replies that benefit from structure (`/status`, `/history`, `/help`, and the all-plates-found celebration) use Telegram's [rich message formatting](https://core.telegram.org/bots/api#rich-message-formatting-options) (Bot API 10.1) — headings, lists, and tables — for a clearer layout.
 
 ---
 

--- a/agents.md
+++ b/agents.md
@@ -64,6 +64,7 @@ Local values live in `local.settings.json` (gitignored). Production values are s
 - **State is stored as JSON in a single Table Storage row** per chat. `SeenStatesJson` is a serialized `List<string>` of 2-letter state abbreviations.
 - **State abbreviations are always uppercased** before storage and comparison. Validation uses the `AllStates` HashSet in `BotCommandHandler`.
 - **Bot replies use HTML parse mode** — use `<b>` for bold, not markdown. Avoid other HTML tags.
+- **Structured replies use rich messages** — `/status`, `/history`, `/help`, and the all-plates-found celebration are sent via `SendRichMessage`/`InputRichMessage.Html` (Bot API 10.1) so they can use `<h1>`-`<h3>`, `<ul>`/`<li>`, and `<table>`. These handlers send directly via `_bot` and return `null` instead of a reply string. Use the `SendRichHtmlAsync` helper for new rich replies.
 - **`PendingCommand` on `TripState`** tracks conversational state (e.g. waiting for a state abbreviation after `/saw` with no argument). Always clear it when a new slash command arrives.
 
 ## Adding a New Command


### PR DESCRIPTION
## Summary

- Closes #34 — Telegram announced Bot API 10.1 "Rich Messages" support (tables, headings, lists, etc. via `sendRichMessage`) on June 13, 2026.
- Upgrades `Telegram.Bot` 21.12.0 → 22.10.1 (adds `InputRichMessage`, `SendRichMessage`, `RichBlock` types for Bot API 10.1).
- Switches `/status`, `/history`, `/help`, and the all-plates-found celebration to `sendRichMessage` with `<h1>`-`<h3>` headings, `<ul>`/`<li>` lists, and `<table>` for leaderboards/history — clearer layout than the previous plain-text formatting.
- Other short confirmation replies (`/saw`, `/skip`, `/undo`, `/missing`, `/newtrip`) are left as plain HTML messages since rich blocks wouldn't add value there.

## Test plan

- [x] `dotnet build` succeeds with 0 errors/warnings against `Telegram.Bot` 22.10.1
- [ ] Manually verify `/status`, `/history`, `/help`, and the celebration message render correctly in Telegram (tables, headings, lists)
- [ ] `/newtrip` resets state correctly
- [ ] `/saw CA` adds a state and reports the correct count
- [ ] `/undo` removes the last state

https://claude.ai/code/session_01Qc4FzmVHkVYvfQuxSuGJAQ


---
_Generated by [Claude Code](https://claude.ai/code/session_01Qc4FzmVHkVYvfQuxSuGJAQ)_